### PR TITLE
LPD-52108 Add support for previous quarterly releases in function reference_new_releases

### DIFF
--- a/release/release_gold.sh
+++ b/release/release_gold.sh
@@ -399,7 +399,7 @@ function reference_new_releases {
 
 	local quarterly_release_branch="release-$(echo "${_PRODUCT_VERSION}" | cut -d '.' -f 1,2)"
 
-	if [ "${quarterly_release_branch}" == "${previous_quarterly_release_branch}" ]
+	if [ "${is_new_quarter}" == "false" ]
 	then
 		replace_property \
 			"portal.latest.bundle.version\[${quarterly_release_branch}\]" \

--- a/release/release_gold.sh
+++ b/release/release_gold.sh
@@ -329,9 +329,13 @@ function reference_new_releases {
 			tail -1 | \
 			cut -d '=' -f 2)"
 
+	local is_new_quarter="false"
+
 	if [ -z "${previous_product_version}" ]
 	then
 		previous_product_version="$(grep "portal.latest.bundle.version\[master\]=" "build.properties" | cut -d '=' -f 2)"
+
+		is_new_quarter="true"
 	fi
 
 	for component in osgi sql tools

--- a/release/release_gold.sh
+++ b/release/release_gold.sh
@@ -320,7 +320,19 @@ function reference_new_releases {
 	fi
 
 	local base_url="http://mirrors.lax.liferay.com/releases.liferay.com"
-	local previous_product_version="$(grep "portal.latest.bundle.version\[master\]=" "build.properties" | cut -d "=" -f 2)"
+
+	local product_group_version="${_PRODUCT_VERSION%.*}"
+
+	local previous_product_version="$(\
+		grep "portal.latest.bundle.version\[${product_group_version}" \
+			"build.properties" | \
+			tail -1 | \
+			cut -d '=' -f 2)"
+
+	if [ -z "${previous_product_version}" ]
+	then
+		previous_product_version="$(grep "portal.latest.bundle.version\[master\]=" "build.properties" | cut -d '=' -f 2)"
+	fi
 
 	for component in osgi sql tools
 	do

--- a/release/release_gold.sh
+++ b/release/release_gold.sh
@@ -376,10 +376,19 @@ function reference_new_releases {
 		"${_PRODUCT_VERSION}" \
 		"portal.latest.bundle.version\[${previous_product_version}\]="
 
-	replace_property \
-		"portal.latest.bundle.version\[master\]" \
-		"${_PRODUCT_VERSION}" \
-		"portal.latest.bundle.version\[master\]=${previous_product_version}"
+	local latest_product_group_version="$(\
+		grep "portal.latest.bundle.version\[master\]=" \
+			"build.properties" | \
+			cut -d '=' -f 2 | \
+			cut -d '.' -f 1,2)"
+
+	if [ "${product_group_version}" == "${latest_product_group_version}" ] || [ "${is_new_quarter}" == "true" ] 
+	then
+		replace_property \
+			"portal.latest.bundle.version\[master\]" \
+			"${_PRODUCT_VERSION}" \
+			"portal.latest.bundle.version\[master\]=${previous_product_version}"
+	fi
 
 	local previous_quarterly_release_branch="$(\
 		grep "portal.latest.bundle.version" \

--- a/release/test-dependencies/expected/build_2024_q3_13.properties
+++ b/release/test-dependencies/expected/build_2024_q3_13.properties
@@ -1,32 +1,43 @@
 
 	plugins.war.zip.url[2024.q3.12]=http://release-1/1/userContent/liferay-release-tool/7413/plugins.war.latest.zip
 	plugins.war.zip.url[2024.q3.13]=http://release-1/1/userContent/liferay-release-tool/7413/plugins.war.latest.zip
+	plugins.war.zip.url[2025.q1.0-lts]=http://release-1/1/userContent/liferay-release-tool/7413/plugins.war.latest.zip
 
-	portal.latest.bundle.version[master]=2024.q3.13
+	portal.latest.bundle.version[master]=2025.q1.0-lts
 
 	portal.latest.bundle.version[2024.q3.12]=2024.q3.12
 	portal.latest.bundle.version[2024.q3.13]=2024.q3.13
+	portal.latest.bundle.version[2025.q1.0-lts]=2025.q1.0-lts
 
 	portal.latest.bundle.version[release-2024.q3]=2024.q3.13
+	portal.latest.bundle.version[release-2025.q1]=2025.q1.0-lts
 
 	portal.license.url[2024.q3.12]=http://www.liferay.com/licenses/license-portaldevelopment-developer-cluster-7.0de-liferaycom.xml
 	portal.license.url[2024.q3.13]=http://www.liferay.com/licenses/license-portaldevelopment-developer-cluster-7.0de-liferaycom.xml
+	portal.license.url[2025.q1.0-lts]=http://www.liferay.com/licenses/license-portaldevelopment-developer-cluster-7.0de-liferaycom.xml
 
 	portal.osgi.zip.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-osgi-2024.q3.12-1733137318.zip
 	portal.osgi.zip.url[2024.q3.13]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.13/liferay-dxp-osgi-2024.q3.13-1695892964.zip
+	portal.osgi.zip.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-osgi-2025.q1.0-lts-1742219407.zip
 
 	portal.sql.zip.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-sql-2024.q3.12-1733137318.zip
 	portal.sql.zip.url[2024.q3.13]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.13/liferay-dxp-sql-2024.q3.13-1695892964.zip
+	portal.sql.zip.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-sql-2025.q1.0-lts-1733137318.zip
 
 	portal.tools.zip.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-tools-2024.q3.12-1733137318.zip
 	portal.tools.zip.url[2024.q3.13]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.13/liferay-dxp-tools-2024.q3.13-1695892964.zip
+	portal.tools.zip.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-tools-2025.q1.0-lts-1733137318.zip
 
 	portal.version.latest[2024.q3.12]=2024.q3.12
 	portal.version.latest[2024.q3.13]=2024.q3.13
+	portal.version.latest[2025.q1.0-lts]=2025.q1.0-lts
 	portal.version.latest[release-2024.q3]=2024.q3.13
+	portal.version.latest[release-2025.q1]=2025.q1.0-lts
 
 	portal.war.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-2024.q3.12-1733137318.war
 	portal.war.url[2024.q3.13]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.13/liferay-dxp-2024.q3.13-1695892964.war
+	portal.war.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-2025.q1.0-lts-1733137318.war
 
 		portal.bundle.tomcat[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-tomcat-2024.q3.12-1733137318.7z
 		portal.bundle.tomcat[2024.q3.13]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.13/liferay-dxp-tomcat-2024.q3.13-1695892964.7z
+		portal.bundle.tomcat[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-tomcat-2025.q1.0-lts-1733137318.7z

--- a/release/test-dependencies/expected/build_2025_q1_1-lts.properties
+++ b/release/test-dependencies/expected/build_2025_q1_1-lts.properties
@@ -1,34 +1,43 @@
 
 	plugins.war.zip.url[2024.q3.12]=http://release-1/1/userContent/liferay-release-tool/7413/plugins.war.latest.zip
 	plugins.war.zip.url[2025.q1.0-lts]=http://release-1/1/userContent/liferay-release-tool/7413/plugins.war.latest.zip
+	plugins.war.zip.url[2025.q1.1-lts]=http://release-1/1/userContent/liferay-release-tool/7413/plugins.war.latest.zip
 
-	portal.latest.bundle.version[master]=2025.q1.0-lts
+	portal.latest.bundle.version[master]=2025.q1.1-lts
 
 	portal.latest.bundle.version[2024.q3.12]=2024.q3.12
 	portal.latest.bundle.version[2025.q1.0-lts]=2025.q1.0-lts
+	portal.latest.bundle.version[2025.q1.1-lts]=2025.q1.1-lts
 
 	portal.latest.bundle.version[release-2024.q3]=2024.q3.12
-	portal.latest.bundle.version[release-2025.q1]=2025.q1.0-lts
+	portal.latest.bundle.version[release-2025.q1]=2025.q1.1-lts
 
 	portal.license.url[2024.q3.12]=http://www.liferay.com/licenses/license-portaldevelopment-developer-cluster-7.0de-liferaycom.xml
 	portal.license.url[2025.q1.0-lts]=http://www.liferay.com/licenses/license-portaldevelopment-developer-cluster-7.0de-liferaycom.xml
+	portal.license.url[2025.q1.1-lts]=http://www.liferay.com/licenses/license-portaldevelopment-developer-cluster-7.0de-liferaycom.xml
 
 	portal.osgi.zip.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-osgi-2024.q3.12-1733137318.zip
 	portal.osgi.zip.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-osgi-2025.q1.0-lts-1742219407.zip
+	portal.osgi.zip.url[2025.q1.1-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.1-lts/liferay-dxp-osgi-2025.q1.1-lts-1695892964.zip
 
 	portal.sql.zip.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-sql-2024.q3.12-1733137318.zip
 	portal.sql.zip.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-sql-2025.q1.0-lts-1733137318.zip
+	portal.sql.zip.url[2025.q1.1-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.1-lts/liferay-dxp-sql-2025.q1.1-lts-1695892964.zip
 
 	portal.tools.zip.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-tools-2024.q3.12-1733137318.zip
 	portal.tools.zip.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-tools-2025.q1.0-lts-1733137318.zip
+	portal.tools.zip.url[2025.q1.1-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.1-lts/liferay-dxp-tools-2025.q1.1-lts-1695892964.zip
 
 	portal.version.latest[2024.q3.12]=2024.q3.12
 	portal.version.latest[2025.q1.0-lts]=2025.q1.0-lts
+	portal.version.latest[2025.q1.1-lts]=2025.q1.1-lts
 	portal.version.latest[release-2024.q3]=2024.q3.12
-	portal.version.latest[release-2025.q1]=2025.q1.0-lts
+	portal.version.latest[release-2025.q1]=2025.q1.1-lts
 
 	portal.war.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-2024.q3.12-1733137318.war
 	portal.war.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-2025.q1.0-lts-1733137318.war
+	portal.war.url[2025.q1.1-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.1-lts/liferay-dxp-2025.q1.1-lts-1695892964.war
 
 		portal.bundle.tomcat[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-tomcat-2024.q3.12-1733137318.7z
 		portal.bundle.tomcat[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-tomcat-2025.q1.0-lts-1733137318.7z
+		portal.bundle.tomcat[2025.q1.1-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.1-lts/liferay-dxp-tomcat-2025.q1.1-lts-1695892964.7z

--- a/release/test-dependencies/expected/build_2025_q2_1.properties
+++ b/release/test-dependencies/expected/build_2025_q2_1.properties
@@ -1,34 +1,45 @@
 
 	plugins.war.zip.url[2024.q3.12]=http://release-1/1/userContent/liferay-release-tool/7413/plugins.war.latest.zip
 	plugins.war.zip.url[2025.q1.0-lts]=http://release-1/1/userContent/liferay-release-tool/7413/plugins.war.latest.zip
+	plugins.war.zip.url[2025.q2.1]=http://release-1/1/userContent/liferay-release-tool/7413/plugins.war.latest.zip
 
-	portal.latest.bundle.version[master]=2025.q1.0-lts
+	portal.latest.bundle.version[master]=2025.q2.1
 
 	portal.latest.bundle.version[2024.q3.12]=2024.q3.12
 	portal.latest.bundle.version[2025.q1.0-lts]=2025.q1.0-lts
+	portal.latest.bundle.version[2025.q2.1]=2025.q2.1
 
 	portal.latest.bundle.version[release-2024.q3]=2024.q3.12
 	portal.latest.bundle.version[release-2025.q1]=2025.q1.0-lts
+	portal.latest.bundle.version[release-2025.q2]=2025.q2.1
 
 	portal.license.url[2024.q3.12]=http://www.liferay.com/licenses/license-portaldevelopment-developer-cluster-7.0de-liferaycom.xml
 	portal.license.url[2025.q1.0-lts]=http://www.liferay.com/licenses/license-portaldevelopment-developer-cluster-7.0de-liferaycom.xml
+	portal.license.url[2025.q2.1]=http://www.liferay.com/licenses/license-portaldevelopment-developer-cluster-7.0de-liferaycom.xml
 
 	portal.osgi.zip.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-osgi-2024.q3.12-1733137318.zip
 	portal.osgi.zip.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-osgi-2025.q1.0-lts-1742219407.zip
+	portal.osgi.zip.url[2025.q2.1]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q2.1/liferay-dxp-osgi-2025.q2.1-1695892964.zip
 
 	portal.sql.zip.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-sql-2024.q3.12-1733137318.zip
 	portal.sql.zip.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-sql-2025.q1.0-lts-1733137318.zip
+	portal.sql.zip.url[2025.q2.1]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q2.1/liferay-dxp-sql-2025.q2.1-1695892964.zip
 
 	portal.tools.zip.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-tools-2024.q3.12-1733137318.zip
 	portal.tools.zip.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-tools-2025.q1.0-lts-1733137318.zip
+	portal.tools.zip.url[2025.q2.1]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q2.1/liferay-dxp-tools-2025.q2.1-1695892964.zip
 
 	portal.version.latest[2024.q3.12]=2024.q3.12
 	portal.version.latest[2025.q1.0-lts]=2025.q1.0-lts
+	portal.version.latest[2025.q2.1]=2025.q2.1
 	portal.version.latest[release-2024.q3]=2024.q3.12
 	portal.version.latest[release-2025.q1]=2025.q1.0-lts
+	portal.version.latest[release-2025.q2]=2025.q2.1
 
 	portal.war.url[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-2024.q3.12-1733137318.war
 	portal.war.url[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-2025.q1.0-lts-1733137318.war
+	portal.war.url[2025.q2.1]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q2.1/liferay-dxp-2025.q2.1-1695892964.war
 
 		portal.bundle.tomcat[2024.q3.12]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2024.q3.12/liferay-dxp-tomcat-2024.q3.12-1733137318.7z
 		portal.bundle.tomcat[2025.q1.0-lts]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q1.0-lts/liferay-dxp-tomcat-2025.q1.0-lts-1733137318.7z
+		portal.bundle.tomcat[2025.q2.1]=http://mirrors.lax.liferay.com/releases.liferay.com/dxp/2025.q2.1/liferay-dxp-tomcat-2025.q2.1-1695892964.7z

--- a/release/test_release_gold.sh
+++ b/release/test_release_gold.sh
@@ -138,17 +138,15 @@ function _test_prepare_next_release_branch {
 }
 
 function test_reference_new_releases {
-	lc_cd "test-dependencies/actual"
+	_test_reference_new_releases "2024.q3.13"
 
-	_PRODUCT_VERSION="2024.q3.13"
+	git restore "test-dependencies/actual/build.properties"
 
-	reference_new_releases --test 1> /dev/null
+	_test_reference_new_releases "2025.q1.1-lts"
 
-	lc_cd "${_PROJECTS_DIR}/liferay-docker/release"
+	git restore "test-dependencies/actual/build.properties"
 
-	assert_equals \
-		test-dependencies/actual/build.properties \
-		test-dependencies/expected/build.properties
+	_test_reference_new_releases "2025.q2.1"
 }
 
 function test_update_release_info_date {
@@ -181,6 +179,24 @@ function _test_not_reference_new_releases {
 	reference_new_releases --test 1> /dev/null
 
 	assert_equals "${?}" "${2}"
+}
+
+function _test_reference_new_releases {
+	_PRODUCT_VERSION="${1}"
+
+	echo -e "Running _test_reference_new_releases for ${_PRODUCT_VERSION}.\n"
+
+	lc_cd "test-dependencies/actual"
+
+	reference_new_releases --test 1> /dev/null
+
+	lc_cd "${_PROJECTS_DIR}/liferay-docker/release"
+
+	local build_properties_file="build_${1//./_}.properties"
+
+	assert_equals \
+		"test-dependencies/actual/build.properties" \
+		"test-dependencies/expected/${build_properties_file}"
 }
 
 function _test_not_update_release_info_date {


### PR DESCRIPTION
**[LPD-52108](https://liferay.atlassian.net/browse/LPD-52108)**

## Proposed solution

- [6179314](https://github.com/liferay-release/liferay-docker/pull/150/commits/6179314909c99203a34578e34b72ffc608f3f17f): Instead of [retrieving the previous product version](https://github.com/liferay-release/liferay-docker/pull/150/commits/6179314909c99203a34578e34b72ffc608f3f17f#diff-85394bff6425b261d641d5876a0c4b0a762ba30b9c6fb058ae80e8079bded80cL323) of the latest quarter, first check if there are any references to the quarter of the new release being added. This will allow retrieving the latest version of previous quarterly releases.
- [27d71d9](https://github.com/liferay-release/liferay-docker/pull/150/commits/27d71d97b409a1f2c29c7d0b951afc09ee2b5c8f): If there are no references to the quarter of the new release being added, it means a new quarter has started. This variable will be used for checks in the next commits.
- [3f9f7cf](https://github.com/liferay-release/liferay-docker/pull/150/commits/3f9f7cffd81bb99435a418d0e7ecb8082d6a1882): This property should only be updated with the most recent version of the latest quarter. In practice, update it only if the product version group matches the latest one or if it is a new quarter (e.g., `2025.q1.12-lts → 2025.q2.1`).
- [b441245](https://github.com/liferay-release/liferay-docker/pull/150/commits/b441245d168b306c22c2c36c05482b24a1519082): New properties like these ([1](https://github.com/liferay/liferay-jenkins-ee/blob/master/commands/build.properties#L4012), [2](https://github.com/liferay/liferay-jenkins-ee/blob/master/commands/build.properties#L2631)) should only be added for new quarters; otherwise, the existing ones should be updated.
- [b165ba4](https://github.com/liferay-release/liferay-docker/pull/150/commits/b165ba402409ec0f77d71773a06a35a1311c6a63): Tests for each scenario:
  - [When using a version from a previous quarter](https://github.com/liferay-release/liferay-docker/pull/150/commits/b165ba402409ec0f77d71773a06a35a1311c6a63#diff-beed4cd1906a6c7e572b50b296a59eb5b6cf46988c7dffbb85f3607f6668d364R141)
  - [When using a version from the latest quarter](https://github.com/liferay-release/liferay-docker/pull/150/commits/b165ba402409ec0f77d71773a06a35a1311c6a63#diff-beed4cd1906a6c7e572b50b296a59eb5b6cf46988c7dffbb85f3607f6668d364R145)
  - [When using the first version of a new quarter](https://github.com/liferay-release/liferay-docker/pull/150/commits/b165ba402409ec0f77d71773a06a35a1311c6a63#diff-beed4cd1906a6c7e572b50b296a59eb5b6cf46988c7dffbb85f3607f6668d364R149)