### PR TITLE
LPD-97578 update_portal_repository fails with "Need to specify how to reconcile divergent branches" when local master diverges from upstream

### DIFF
--- a/crowdin/crowdin_sync.sh
+++ b/crowdin/crowdin_sync.sh
@@ -198,7 +198,9 @@ function update_portal_repository {
 		git remote add upstream "git@github.com:liferay/liferay-portal.git"
 	fi
 
-	git pull upstream master
+	git fetch upstream master
+
+	git reset --hard upstream/master
 
 	if ! git remote get-url liferay-release &> /dev/null
 	then


### PR DESCRIPTION
**Related ticket: [LPD-97578](https://liferay.atlassian.net/browse/LPD-97578)**