### PR TITLE
LPD-97578 update_portal_repository fails with "Need to specify how to reconcile divergent branches" when local master diverges from upstream

### DIFF
--- a/crowdin/crowdin_sync.sh
+++ b/crowdin/crowdin_sync.sh
@@ -203,7 +203,7 @@ function update_portal_repository {
 		git remote add upstream "git@github.com:liferay/liferay-portal.git"
 	fi
 
-	git fetch upstream master
+	git fetch upstream "master:refs/remotes/upstream/master"
 
 	git reset --hard upstream/master
 


### PR DESCRIPTION
**Related ticket: [LPD-97578](https://liferay.atlassian.net/browse/LPD-97578)**