### PR TITLE
LPD-102431 Put Node on PATH so derived images can run npm at build time

### DIFF
--- a/templates/node-runner/Dockerfile
+++ b/templates/node-runner/Dockerfile
@@ -15,6 +15,7 @@ ENTRYPOINT ["tini", "-v", "--", "/usr/local/bin/liferay_node_runner_entrypoint.s
 ENV LANG="C.UTF-8"
 ENV LIFERAY_NODE_RUNNER_START="npm start"
 ENV NODE_VERSION="v22"
+ENV PATH="/usr/local/node/${NODE_VERSION}/bin:${PATH}"
 
 LABEL org.label-schema.build-date="${LABEL_BUILD_DATE}"
 LABEL org.label-schema.name="${LABEL_NAME}"

--- a/test_build_node_runner_image.sh
+++ b/test_build_node_runner_image.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+source ./_liferay_common.sh
+source ./_test_common.sh
+
+function main {
+	set_up
+
+	if [[ "${#}" -eq 1 ]]
+	then
+		"${1}"
+	else
+		test_build_node_runner_image_derived_image_installs_dependencies
+		test_build_node_runner_image_entrypoint_starts_default_command
+		test_build_node_runner_image_has_node_on_path
+		test_build_node_runner_image_switches_node_version
+	fi
+
+	tear_down
+}
+
+function set_up {
+	export _TEST_DERIVED_IMAGE="liferay/node-runner-derived:test"
+	export _TEST_NODE_RUNNER_IMAGE="liferay/node-runner:test"
+
+	docker build --tag "${_TEST_NODE_RUNNER_IMAGE}" templates/node-runner &> /dev/null
+
+	export _TEST_APP_DIR=$(mktemp --directory)
+
+	echo 'console.log("[LIFERAY_NODE_RUNNER_TEST] started");' > "${_TEST_APP_DIR}/app.js"
+
+	cat <<- EOF > "${_TEST_APP_DIR}/package.json"
+	{
+		"dependencies": {
+			"left-pad": "1.3.0"
+		},
+		"name": "liferay-node-runner-test",
+		"scripts": {
+			"start": "node app.js"
+		},
+		"version": "1.0.0"
+	}
+	EOF
+
+	cat <<- EOF > "${_TEST_APP_DIR}/Dockerfile"
+	FROM ${_TEST_NODE_RUNNER_IMAGE}
+
+	COPY --chown=liferay:liferay app.js package.json ./
+
+	RUN npm install --no-workspaces
+	EOF
+
+	docker build --tag "${_TEST_DERIVED_IMAGE}" "${_TEST_APP_DIR}" &> /dev/null
+}
+
+function tear_down {
+	docker rmi --force "${_TEST_DERIVED_IMAGE}" &> /dev/null
+	docker rmi --force "${_TEST_NODE_RUNNER_IMAGE}" &> /dev/null
+
+	rm --force --recursive "${_TEST_APP_DIR}"
+
+	unset _TEST_APP_DIR
+	unset _TEST_DERIVED_IMAGE
+	unset _TEST_NODE_RUNNER_IMAGE
+}
+
+function test_build_node_runner_image_derived_image_installs_dependencies {
+	assert_equals \
+		"$(docker run --entrypoint ls --rm "${_TEST_DERIVED_IMAGE}" node_modules)" \
+		"left-pad"
+}
+
+function test_build_node_runner_image_entrypoint_starts_default_command {
+	assert_equals \
+		"$(docker run --rm "${_TEST_DERIVED_IMAGE}" 2>&1 | grep --fixed-strings "[LIFERAY_NODE_RUNNER_TEST] started")" \
+		"[LIFERAY_NODE_RUNNER_TEST] started"
+}
+
+function test_build_node_runner_image_has_node_on_path {
+	assert_equals \
+		"$(docker run --entrypoint bash --rm "${_TEST_NODE_RUNNER_IMAGE}" -c 'command -v node &> /dev/null && command -v npm &> /dev/null && echo "true"')" \
+		"true"
+}
+
+function test_build_node_runner_image_switches_node_version {
+	assert_equals \
+		"$(_test_build_node_runner_image_node_version "v22")" \
+		"v22" \
+		"$(_test_build_node_runner_image_node_version "v24")" \
+		"v24"
+}
+
+function _test_build_node_runner_image_node_version {
+	docker run \
+		--env LIFERAY_NODE_RUNNER_START="node --version" \
+		--env NODE_VERSION="${1}" \
+		--rm \
+		"${_TEST_NODE_RUNNER_IMAGE}" 2>&1 | \
+		grep --extended-regexp "^v[0-9]+" | \
+		cut --delimiter='.' --fields=1
+}
+
+main "${@}"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102431

Regression from LPD-98466, reported by support in PTR-9125. A customer can no longer build a Node Client Extension from a single-stage Dockerfile.

## The bug

Node is installed to `/usr/local/node/v22/bin` and `/usr/local/node/v24/bin`. Nothing puts either on the image `PATH`:

```
$ docker inspect liferay/node-runner:latest --format '{{range .Config.Env}}{{println .}}{{end}}'
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
LANG=C.UTF-8
LIFERAY_NODE_RUNNER_START=npm start
NODE_VERSION=v22
```

`PATH` is only extended at runtime, by `set_node_version.sh`, which the entrypoint sources. Docker `RUN` layers never go through `ENTRYPOINT`, so a derived image cannot run npm at all:

```
FROM liferay/node-runner:latest
RUN npm install --no-workspaces
==> /bin/sh: 1: npm: not found     (exit code 127)
```

Identical failure with `NODE_VERSION` unset, `v22`, or `v24` — nothing reads that variable during `docker build`. Before LPD-98466 node came from apt in `/usr/bin`, already on `PATH`. This blocks the normal way a CX is built, since a CX is built from a derived image.

## Fix

One line — bake the default version's bin directory into `PATH`:

```
ENV PATH="/usr/local/node/${NODE_VERSION}/bin:${PATH}"
```

Runtime version switching is preserved, because the entrypoint prepends the selected version and so still wins over the baked-in default. Verified `NODE_VERSION=v24` yields `v24.17.0` and the default yields `v22.23.0`.

Caveat: a derived image's build-time `RUN npm ...` resolves to the default version's npm, since `ENV PATH` is fixed at build time. Selecting a version at build time means going through the entrypoint, which currently discards its arguments — that is **LPD-102472**, split out so this regression fix stays uncontroversial.

## Test

Adds `test_build_node_runner_image.sh`. The load-bearing case builds a *derived* image that runs `npm install` in a `RUN` layer and asserts `node_modules` exists.

**3 of the 4 cases fail without this fix.** The fourth, runtime version switching, passes either way — it is there to catch a regression from baking `PATH` in, not to reproduce the bug.

Nothing covered this path before, which is why it shipped looking healthy: `install_node.sh` verifies node by absolute path (`"${target_dir}/bin/node" --version`), so the image build stayed green, and the runtime path repairs `PATH` itself, so `docker run` worked.

`sf.sh` run against the changed files; the only errors it reports are pre-existing, in a Java file under `narwhal/` untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
