### PR TITLE
LPD-82260 Make the batch entrypoint report why an import failed

### DIFF
--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -38,12 +38,7 @@ function main {
 	LIFERAY_BATCH_OAUTH2_CLIENT_SECRET=$(cat "${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.headless.server.client.secret")
 	LIFERAY_BATCH_OAUTH2_TOKEN_URI=$(cat "${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.token.uri")
 
-	echo "LXC DXP Main Domain: ${lxc_dxp_main_domain}"
-	echo "LXC DXP Server Protocol: $(cat "${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.server.protocol")"
-	echo ""
-	echo "OAuth Client ID: ${LIFERAY_BATCH_OAUTH2_CLIENT_ID}"
-	echo "OAuth Client Secret: ${LIFERAY_BATCH_OAUTH2_CLIENT_SECRET}"
-	echo "OAuth Token URI: ${LIFERAY_BATCH_OAUTH2_TOKEN_URI}"
+	echo "DXP URL: ${LIFERAY_BATCH_DXP_URL}"
 	echo ""
 
 	if ! request_oauth2_access_token
@@ -229,9 +224,6 @@ function request_oauth2_access_token {
 
 		return 1
 	fi
-
-	echo "OAuth Token Response: ${oauth2_token_response}"
-	echo ""
 
 	LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN=$(jq --raw-output ".access_token" <<< "${oauth2_token_response}")
 

--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -33,220 +33,258 @@ function main {
 		lxc_dxp_main_domain=$(cat "${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.mainDomain")
 	fi
 
-	local lxc_dxp_server_protocol=$(cat "${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.server.protocol")
-	local oauth2_client_id=$(cat "${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.headless.server.client.id")
-	local oauth2_client_secret=$(cat "${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.headless.server.client.secret")
-	local oauth2_token_uri=$(cat "${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.token.uri")
+	LIFERAY_BATCH_DXP_URL="$(cat "${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.server.protocol")://${lxc_dxp_main_domain}"
+	LIFERAY_BATCH_OAUTH2_CLIENT_ID=$(cat "${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.headless.server.client.id")
+	LIFERAY_BATCH_OAUTH2_CLIENT_SECRET=$(cat "${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.headless.server.client.secret")
+	LIFERAY_BATCH_OAUTH2_TOKEN_URI=$(cat "${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.token.uri")
 
 	echo "LXC DXP Main Domain: ${lxc_dxp_main_domain}"
-	echo "LXC DXP Server Protocol: ${lxc_dxp_server_protocol}"
+	echo "LXC DXP Server Protocol: $(cat "${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.server.protocol")"
 	echo ""
-	echo "OAuth Client ID: ${oauth2_client_id}"
-	echo "OAuth Client Secret: ${oauth2_client_secret}"
-	echo "OAuth Token URI: ${oauth2_token_uri}"
+	echo "OAuth Client ID: ${LIFERAY_BATCH_OAUTH2_CLIENT_ID}"
+	echo "OAuth Client Secret: ${LIFERAY_BATCH_OAUTH2_CLIENT_SECRET}"
+	echo "OAuth Token URI: ${LIFERAY_BATCH_OAUTH2_TOKEN_URI}"
 	echo ""
 
-	local http_status_code_file=$(mktemp)
-
-	local oauth2_token_response=$( \
-		curl \
-			--data "client_id=${oauth2_client_id}&client_secret=${oauth2_client_secret}&grant_type=client_credentials" \
-			--header "Content-type: application/x-www-form-urlencoded" \
-			--request POST \
-			--silent \
-			--write-out "%output{${http_status_code_file}}%{http_code}" \
-			${LIFERAY_BATCH_CURL_OPTIONS} \
-			"${lxc_dxp_server_protocol}://${lxc_dxp_main_domain}${oauth2_token_uri}")
-
-	local http_status_code=$(cat "${http_status_code_file}")
-
-	if [[ "${http_status_code}" -ge 400 ]]
+	if ! request_oauth2_access_token
 	then
-		echo "POST ${lxc_dxp_server_protocol}://${lxc_dxp_main_domain}${oauth2_token_uri} errored with HTTP status ${http_status_code}."
-
 		exit 1
 	fi
 
-	echo "OAuth Token Response: ${oauth2_token_response}"
-	echo ""
-
-	local oauth2_access_token=$(jq --raw-output ".access_token" <<< "${oauth2_token_response}")
-
-	if [ "${oauth2_access_token}" == "" ]
+	if ! process_site_initializer
 	then
-		echo "Unable to get OAuth 2 access token."
-
 		exit 1
-	fi
-
-	if [ -e "/opt/liferay/site-initializer/site-initializer.json" ]
-	then
-		echo "Processing: /opt/liferay/site-initializer/site-initializer.json"
-		echo ""
-
-		local href="/o/headless-site/v1.0/sites/by-external-reference-code/"
-
-		echo "HREF: ${href}"
-
-		local site=$(jq --raw-output '.' /opt/liferay/site-initializer/site-initializer.json)
-
-		echo "Site: ${site}"
-
-		local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${site}")
-
-		local http_status_code_file=$(mktemp)
-
-		local put_response=$( \
-			curl \
-				--form "file=@/opt/liferay/site-initializer/site-initializer.zip;type=application/zip" \
-				--form "site=${site}" \
-				--header "Accept: application/json" \
-				--header "Authorization: Bearer ${oauth2_access_token}" \
-				--header "Content-Type: multipart/form-data" \
-				--request PUT \
-				--silent \
-				--write-out "%output{${http_status_code_file}}%{http_code}" \
-				${LIFERAY_BATCH_CURL_OPTIONS} \
-				"${lxc_dxp_server_protocol}://${lxc_dxp_main_domain}${href}${external_reference_code}")
-
-		local http_status_code=$(cat "${http_status_code_file}")
-
-		if [[ "${http_status_code}" -ge 400 ]]
-		then
-			echo "PUT ${lxc_dxp_server_protocol}://${lxc_dxp_main_domain}${href}${external_reference_code} errored with HTTP status ${http_status_code}."
-
-			exit 1
-		fi
-
-		echo "PUT Response: ${put_response}"
-		echo ""
-
-		if [ ! -n "${put_response}" ]
-		then
-			echo "Received empty PUT response. Check Liferay logs for more information."
-
-			exit 1
-		fi
 	fi
 
 	find /opt/liferay/batch -type f -name "*.batch-engine-data.json" -print0 2> /dev/null | LC_ALL=C sort --zero-terminated |
 	while IFS= read -r -d "" file_name
 	do
-		echo "Processing: ${file_name}"
-		echo ""
-
-		local href=$(jq --raw-output ".actions.createBatch.href" "${file_name}")
-
-		if [ "${href}" == "null" ]
+		if ! process_batch_data_file "${file_name}"
 		then
-			local class_name=$(jq --raw-output ".configuration.className" "${file_name}")
-
-			if [ "${class_name}" == "null" ]
-			then
-				echo "Batch data file is missing configuration class name."
-
-				exit 1
-			fi
-
-			href="/o/headless-batch-engine/v1.0/import-task/${class_name}"
-		fi
-
-		href="${href#*://*/}"
-
-		if [[ ! ${href} =~ ^/.* ]]
-		then
-			href="/${href}"
-		fi
-
-		echo "HREF: ${href}"
-
-		jq --raw-output ".items" "${file_name}" > /tmp/liferay_batch_entrypoint.items.json
-
-		echo "Items: $(</tmp/liferay_batch_entrypoint.items.json)"
-
-		local parameters=$(jq --raw-output '.configuration.parameters | [map_values(. | @uri) | to_entries[] | .key + "=" + .value] | join("&")' "${file_name}" 2> /dev/null)
-
-		if [ "${parameters}" != "" ]
-		then
-			parameters="?${parameters}"
-		fi
-
-		echo "Parameters: ${parameters}"
-
-		local http_status_code_file=$(mktemp)
-
-		local post_response=$( \
-			curl \
-				--data @/tmp/liferay_batch_entrypoint.items.json \
-				--header "Accept: application/json" \
-				--header "Authorization: Bearer ${oauth2_access_token}" \
-				--header "Content-Type: application/json" \
-				--request POST \
-				--silent \
-				--write-out "%output{${http_status_code_file}}%{http_code}" \
-				${LIFERAY_BATCH_CURL_OPTIONS} \
-				"${lxc_dxp_server_protocol}://${lxc_dxp_main_domain}${href}${parameters}")
-
-		local http_status_code=$(cat "${http_status_code_file}")
-
-		if [[ "${http_status_code}" -ge 400 ]]
-		then
-			echo "POST ${lxc_dxp_server_protocol}://${lxc_dxp_main_domain}${href}${parameters} errored with HTTP status ${http_status_code}."
-
-			exit 1
-		fi
-
-		echo "POST Response: ${post_response}"
-		echo ""
-
-		if [ ! -n "${post_response}" ]
-		then
-			echo "Received empty POST response. Check Liferay logs for more information."
-
-			rm /tmp/liferay_batch_entrypoint.items.json
-
-			exit 1
-		fi
-
-		local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${post_response}")
-
-		local status=$(jq --raw-output ".executeStatus//.status" <<< "${post_response}")
-
-		until [ "${status}" == "COMPLETED" ] || [ "${status}" == "FAILED" ] || [ "${status}" == "NOT_FOUND" ]
-		do
-			local http_status_code_file=$(mktemp)
-
-			local get_response=$( \
-				curl \
-					--header "accept: application/json" \
-					--header "Authorization: Bearer ${oauth2_access_token}" \
-					--request 'GET' \
-					--silent \
-					--write-out "%output{${http_status_code_file}}%{http_code}" \
-					${LIFERAY_BATCH_CURL_OPTIONS} \
-					"${lxc_dxp_server_protocol}://${lxc_dxp_main_domain}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code}")
-
-			if [[ "${http_status_code}" -ge 400 ]]
-			then
-				echo "GET ${lxc_dxp_server_protocol}://${lxc_dxp_main_domain}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code} errored with HTTP status ${http_status_code}."
-
-				exit 1
-			fi
-
-			status=$(jq --raw-output '.executeStatus//.status' <<< "${get_response}")
-
-			echo "Execute Status: ${status}"
-		done
-
-		rm /tmp/liferay_batch_entrypoint.items.json
-
-		if [ "${status}" == "FAILED" ]
-		then
-			echo "Batch import task failed. Check Liferay logs for more information."
-
 			exit 1
 		fi
 	done
+}
+
+function process_batch_data_file {
+	local file_name="${1}"
+
+	echo "Processing: ${file_name}"
+	echo ""
+
+	local href=$(jq --raw-output ".actions.createBatch.href" "${file_name}")
+
+	if [ "${href}" == "null" ]
+	then
+		local class_name=$(jq --raw-output ".configuration.className" "${file_name}")
+
+		if [ "${class_name}" == "null" ]
+		then
+			echo "Batch data file is missing configuration class name."
+
+			return 1
+		fi
+
+		href="/o/headless-batch-engine/v1.0/import-task/${class_name}"
+	fi
+
+	href="${href#*://*/}"
+
+	if [[ ! ${href} =~ ^/.* ]]
+	then
+		href="/${href}"
+	fi
+
+	echo "HREF: ${href}"
+
+	jq --raw-output ".items" "${file_name}" > /tmp/liferay_batch_entrypoint.items.json
+
+	echo "Items: $(</tmp/liferay_batch_entrypoint.items.json)"
+
+	local parameters=$(jq --raw-output '.configuration.parameters | [map_values(. | @uri) | to_entries[] | .key + "=" + .value] | join("&")' "${file_name}" 2> /dev/null)
+
+	if [ "${parameters}" != "" ]
+	then
+		parameters="?${parameters}"
+	fi
+
+	echo "Parameters: ${parameters}"
+
+	local http_status_code_file=$(mktemp)
+
+	local post_response=$( \
+		curl \
+			--data @/tmp/liferay_batch_entrypoint.items.json \
+			--header "Accept: application/json" \
+			--header "Authorization: Bearer ${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" \
+			--header "Content-Type: application/json" \
+			--request POST \
+			--silent \
+			--write-out "%output{${http_status_code_file}}%{http_code}" \
+			${LIFERAY_BATCH_CURL_OPTIONS} \
+			"${LIFERAY_BATCH_DXP_URL}${href}${parameters}")
+
+	local http_status_code=$(cat "${http_status_code_file}")
+
+	if [[ "${http_status_code}" -ge 400 ]]
+	then
+		echo "POST ${LIFERAY_BATCH_DXP_URL}${href}${parameters} errored with HTTP status ${http_status_code}."
+
+		return 1
+	fi
+
+	echo "POST Response: ${post_response}"
+	echo ""
+
+	if [ ! -n "${post_response}" ]
+	then
+		echo "Received empty POST response. Check Liferay logs for more information."
+
+		rm /tmp/liferay_batch_entrypoint.items.json
+
+		return 1
+	fi
+
+	local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${post_response}")
+
+	local status=$(jq --raw-output ".executeStatus//.status" <<< "${post_response}")
+
+	wait_for_import_task "${external_reference_code}" "${status}"
+}
+
+function process_site_initializer {
+	if [ ! -e "/opt/liferay/site-initializer/site-initializer.json" ]
+	then
+		return 0
+	fi
+
+	echo "Processing: /opt/liferay/site-initializer/site-initializer.json"
+	echo ""
+
+	local href="/o/headless-site/v1.0/sites/by-external-reference-code/"
+
+	echo "HREF: ${href}"
+
+	local site=$(jq --raw-output '.' /opt/liferay/site-initializer/site-initializer.json)
+
+	echo "Site: ${site}"
+
+	local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${site}")
+
+	local http_status_code_file=$(mktemp)
+
+	local put_response=$( \
+		curl \
+			--form "file=@/opt/liferay/site-initializer/site-initializer.zip;type=application/zip" \
+			--form "site=${site}" \
+			--header "Accept: application/json" \
+			--header "Authorization: Bearer ${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" \
+			--header "Content-Type: multipart/form-data" \
+			--request PUT \
+			--silent \
+			--write-out "%output{${http_status_code_file}}%{http_code}" \
+			${LIFERAY_BATCH_CURL_OPTIONS} \
+			"${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code}")
+
+	local http_status_code=$(cat "${http_status_code_file}")
+
+	if [[ "${http_status_code}" -ge 400 ]]
+	then
+		echo "PUT ${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code} errored with HTTP status ${http_status_code}."
+
+		return 1
+	fi
+
+	echo "PUT Response: ${put_response}"
+	echo ""
+
+	if [ ! -n "${put_response}" ]
+	then
+		echo "Received empty PUT response. Check Liferay logs for more information."
+
+		return 1
+	fi
+
+	return 0
+}
+
+function request_oauth2_access_token {
+	local http_status_code_file=$(mktemp)
+
+	local oauth2_token_response=$( \
+		curl \
+			--data "client_id=${LIFERAY_BATCH_OAUTH2_CLIENT_ID}&client_secret=${LIFERAY_BATCH_OAUTH2_CLIENT_SECRET}&grant_type=client_credentials" \
+			--header "Content-type: application/x-www-form-urlencoded" \
+			--request POST \
+			--silent \
+			--write-out "%output{${http_status_code_file}}%{http_code}" \
+			${LIFERAY_BATCH_CURL_OPTIONS} \
+			"${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI}")
+
+	local http_status_code=$(cat "${http_status_code_file}")
+
+	if [[ "${http_status_code}" -ge 400 ]]
+	then
+		echo "POST ${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI} errored with HTTP status ${http_status_code}."
+
+		return 1
+	fi
+
+	echo "OAuth Token Response: ${oauth2_token_response}"
+	echo ""
+
+	LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN=$(jq --raw-output ".access_token" <<< "${oauth2_token_response}")
+
+	if [ "${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" == "" ]
+	then
+		echo "Unable to get OAuth 2 access token."
+
+		return 1
+	fi
+
+	return 0
+}
+
+function wait_for_import_task {
+	local external_reference_code="${1}"
+	local status="${2}"
+
+	until [ "${status}" == "COMPLETED" ] || [ "${status}" == "FAILED" ] || [ "${status}" == "NOT_FOUND" ]
+	do
+		local http_status_code_file=$(mktemp)
+
+		local get_response=$( \
+			curl \
+				--header "accept: application/json" \
+				--header "Authorization: Bearer ${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" \
+				--request 'GET' \
+				--silent \
+				--write-out "%output{${http_status_code_file}}%{http_code}" \
+				${LIFERAY_BATCH_CURL_OPTIONS} \
+				"${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code}")
+
+		if [[ "${http_status_code}" -ge 400 ]]
+		then
+			echo "GET ${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code} errored with HTTP status ${http_status_code}."
+
+			return 1
+		fi
+
+		status=$(jq --raw-output '.executeStatus//.status' <<< "${get_response}")
+
+		echo "Execute Status: ${status}"
+	done
+
+	rm /tmp/liferay_batch_entrypoint.items.json
+
+	if [ "${status}" == "FAILED" ]
+	then
+		echo "Batch import task failed. Check Liferay logs for more information."
+
+		return 1
+	fi
+
+	return 0
 }
 
 main

--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -260,9 +260,20 @@ function wait_for_import_task {
 
 	rm /tmp/liferay_batch_entrypoint.items.json
 
-	if [ "${status}" == "FAILED" ]
+	if [ "${status}" == "FAILED" ] || [ "${status}" == "NOT_FOUND" ]
 	then
-		echo "Batch import task failed. Check Liferay logs for more information."
+		echo "Batch import task ${external_reference_code} reported ${status}. ${LIFERAY_BATCH_HTTP_BODY}"
+
+		return 1
+	fi
+
+	local failed_items
+
+	failed_items=$(jq --raw-output '.failedItems//[] | length' <<< "${LIFERAY_BATCH_HTTP_BODY}")
+
+	if [ "${failed_items}" != "0" ]
+	then
+		echo "Batch import task ${external_reference_code} completed with ${failed_items} failed item(s). ${LIFERAY_BATCH_HTTP_BODY}"
 
 		return 1
 	fi

--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -33,6 +33,16 @@ function main {
 		exit 1
 	fi
 
+	if [ ! -n "${LIFERAY_BATCH_DIR}" ]
+	then
+		LIFERAY_BATCH_DIR="/opt/liferay/batch"
+	fi
+
+	if [ ! -n "${LIFERAY_BATCH_SITE_INITIALIZER_DIR}" ]
+	then
+		LIFERAY_BATCH_SITE_INITIALIZER_DIR="/opt/liferay/site-initializer"
+	fi
+
 	if [ ! -n "${LIFERAY_BATCH_CURL_OPTIONS}" ]
 	then
 		LIFERAY_BATCH_CURL_OPTIONS=" "
@@ -81,7 +91,7 @@ function main {
 		exit 1
 	fi
 
-	find /opt/liferay/batch -type f -name "*.batch-engine-data.json" -print0 2> /dev/null | LC_ALL=C sort --zero-terminated |
+	find ${LIFERAY_BATCH_DIR} -type f -name "*.batch-engine-data.json" -print0 2> /dev/null | LC_ALL=C sort --zero-terminated |
 	while IFS= read -r -d "" file_name
 	do
 		if ! process_batch_data_file "${file_name}"
@@ -178,26 +188,26 @@ function process_batch_data_file {
 }
 
 function process_site_initializer {
-	if [ ! -e "/opt/liferay/site-initializer/site-initializer.json" ]
+	if [ ! -e "${LIFERAY_BATCH_SITE_INITIALIZER_DIR}/site-initializer.json" ]
 	then
 		return 0
 	fi
 
-	echo "Processing: /opt/liferay/site-initializer/site-initializer.json"
+	echo "Processing: ${LIFERAY_BATCH_SITE_INITIALIZER_DIR}/site-initializer.json"
 	echo ""
 
 	local href="/o/headless-site/v1.0/sites/by-external-reference-code/"
 
 	echo "HREF: ${href}"
 
-	local site=$(jq --raw-output '.' /opt/liferay/site-initializer/site-initializer.json)
+	local site=$(jq --raw-output '.' "${LIFERAY_BATCH_SITE_INITIALIZER_DIR}/site-initializer.json")
 
 	echo "Site: ${site}"
 
 	local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${site}")
 
 	if ! execute_curl \
-			--form "file=@/opt/liferay/site-initializer/site-initializer.zip;type=application/zip" \
+			--form "file=@${LIFERAY_BATCH_SITE_INITIALIZER_DIR}/site-initializer.zip;type=application/zip" \
 			--form "site=${site}" \
 			--header "Accept: application/json" \
 			--header "Authorization: Bearer ${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" \

--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -38,6 +38,11 @@ function main {
 		LIFERAY_BATCH_CURL_OPTIONS=" "
 	fi
 
+	if [ ! -n "${LIFERAY_BATCH_MAX_WAIT_SECONDS}" ]
+	then
+		LIFERAY_BATCH_MAX_WAIT_SECONDS=540
+	fi
+
 	if [ ! -n "${LIFERAY_ROUTES_CLIENT_EXTENSION}" ]
 	then
 		LIFERAY_ROUTES_CLIENT_EXTENSION="/etc/liferay/lxc/ext-init-metadata"
@@ -158,9 +163,13 @@ function process_batch_data_file {
 
 	local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${LIFERAY_BATCH_HTTP_BODY}")
 
-	local status=$(jq --raw-output ".executeStatus//.status" <<< "${LIFERAY_BATCH_HTTP_BODY}")
+	wait_for_import_task "${external_reference_code}"
 
-	wait_for_import_task "${external_reference_code}" "${status}"
+	local exit_code=${?}
+
+	rm /tmp/liferay_batch_entrypoint.items.json
+
+	return ${exit_code}
 }
 
 function process_site_initializer {
@@ -237,9 +246,11 @@ function request_oauth2_access_token {
 
 function wait_for_import_task {
 	local external_reference_code="${1}"
-	local status="${2}"
 
-	until [ "${status}" == "COMPLETED" ] || [ "${status}" == "FAILED" ] || [ "${status}" == "NOT_FOUND" ]
+	local sleep_seconds=1
+	local waited_seconds=0
+
+	while true
 	do
 		if ! execute_curl \
 				--header "Accept: application/json" \
@@ -253,32 +264,56 @@ function wait_for_import_task {
 			return 1
 		fi
 
-		status=$(jq --raw-output '.executeStatus//.status' <<< "${LIFERAY_BATCH_HTTP_BODY}")
+		local status
+
+		if ! status=$(jq --exit-status --raw-output '.executeStatus//.status' <<< "${LIFERAY_BATCH_HTTP_BODY}")
+		then
+			echo "Unable to read a status for batch import task ${external_reference_code}. ${LIFERAY_BATCH_HTTP_BODY}"
+
+			return 1
+		fi
 
 		echo "Execute Status: ${status}"
+
+		if [ "${status}" == "COMPLETED" ]
+		then
+			local failed_items
+
+			failed_items=$(jq --raw-output '.failedItems//[] | length' <<< "${LIFERAY_BATCH_HTTP_BODY}")
+
+			if [ "${failed_items}" != "0" ]
+			then
+				echo "Batch import task ${external_reference_code} completed with ${failed_items} failed item(s). ${LIFERAY_BATCH_HTTP_BODY}"
+
+				return 1
+			fi
+
+			return 0
+		fi
+
+		if [ "${status}" == "FAILED" ] || [ "${status}" == "NOT_FOUND" ]
+		then
+			echo "Batch import task ${external_reference_code} reported ${status}. ${LIFERAY_BATCH_HTTP_BODY}"
+
+			return 1
+		fi
+
+		if [ "${waited_seconds}" -ge "${LIFERAY_BATCH_MAX_WAIT_SECONDS}" ]
+		then
+			echo "Batch import task ${external_reference_code} did not reach a terminal state within ${waited_seconds} seconds. The last reported status was ${status}."
+
+			return 1
+		fi
+
+		sleep "${sleep_seconds}"
+
+		waited_seconds=$((waited_seconds + sleep_seconds))
+
+		if [ "${sleep_seconds}" -lt 15 ]
+		then
+			sleep_seconds=$((sleep_seconds * 2))
+		fi
 	done
-
-	rm /tmp/liferay_batch_entrypoint.items.json
-
-	if [ "${status}" == "FAILED" ] || [ "${status}" == "NOT_FOUND" ]
-	then
-		echo "Batch import task ${external_reference_code} reported ${status}. ${LIFERAY_BATCH_HTTP_BODY}"
-
-		return 1
-	fi
-
-	local failed_items
-
-	failed_items=$(jq --raw-output '.failedItems//[] | length' <<< "${LIFERAY_BATCH_HTTP_BODY}")
-
-	if [ "${failed_items}" != "0" ]
-	then
-		echo "Batch import task ${external_reference_code} completed with ${failed_items} failed item(s). ${LIFERAY_BATCH_HTTP_BODY}"
-
-		return 1
-	fi
-
-	return 0
 }
 
 main

--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -1,5 +1,30 @@
 #!/bin/bash
 
+function execute_curl {
+	local response
+
+	response=$(curl --silent --write-out "\n%{http_code}" "${@}")
+
+	if [ "${?}" -gt 0 ]
+	then
+		LIFERAY_BATCH_HTTP_BODY="Unable to complete the request."
+		LIFERAY_BATCH_HTTP_STATUS="000"
+
+		return 1
+	fi
+
+	LIFERAY_BATCH_HTTP_BODY="${response%$'\n'*}"
+	LIFERAY_BATCH_HTTP_STATUS="${response##*$'\n'}"
+
+	if [ "${LIFERAY_BATCH_HTTP_STATUS}" == "000" ] ||
+	   [ "${LIFERAY_BATCH_HTTP_STATUS}" -ge 400 ]
+	then
+		return 1
+	fi
+
+	return 0
+}
+
 function main {
 	if [ ! -n "${LIFERAY_BATCH_OAUTH_APP_ERC}" ]
 	then
@@ -105,33 +130,24 @@ function process_batch_data_file {
 
 	echo "Parameters: ${parameters}"
 
-	local http_status_code_file=$(mktemp)
-
-	local post_response=$( \
-		curl \
+	if ! execute_curl \
 			--data @/tmp/liferay_batch_entrypoint.items.json \
 			--header "Accept: application/json" \
 			--header "Authorization: Bearer ${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" \
 			--header "Content-Type: application/json" \
 			--request POST \
-			--silent \
-			--write-out "%output{${http_status_code_file}}%{http_code}" \
 			${LIFERAY_BATCH_CURL_OPTIONS} \
-			"${LIFERAY_BATCH_DXP_URL}${href}${parameters}")
-
-	local http_status_code=$(cat "${http_status_code_file}")
-
-	if [[ "${http_status_code}" -ge 400 ]]
+			"${LIFERAY_BATCH_DXP_URL}${href}${parameters}"
 	then
-		echo "POST ${LIFERAY_BATCH_DXP_URL}${href}${parameters} errored with HTTP status ${http_status_code}."
+		echo "POST ${LIFERAY_BATCH_DXP_URL}${href}${parameters} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}."
 
 		return 1
 	fi
 
-	echo "POST Response: ${post_response}"
+	echo "POST Response: ${LIFERAY_BATCH_HTTP_BODY}"
 	echo ""
 
-	if [ ! -n "${post_response}" ]
+	if [ ! -n "${LIFERAY_BATCH_HTTP_BODY}" ]
 	then
 		echo "Received empty POST response. Check Liferay logs for more information."
 
@@ -140,9 +156,9 @@ function process_batch_data_file {
 		return 1
 	fi
 
-	local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${post_response}")
+	local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${LIFERAY_BATCH_HTTP_BODY}")
 
-	local status=$(jq --raw-output ".executeStatus//.status" <<< "${post_response}")
+	local status=$(jq --raw-output ".executeStatus//.status" <<< "${LIFERAY_BATCH_HTTP_BODY}")
 
 	wait_for_import_task "${external_reference_code}" "${status}"
 }
@@ -166,34 +182,25 @@ function process_site_initializer {
 
 	local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${site}")
 
-	local http_status_code_file=$(mktemp)
-
-	local put_response=$( \
-		curl \
+	if ! execute_curl \
 			--form "file=@/opt/liferay/site-initializer/site-initializer.zip;type=application/zip" \
 			--form "site=${site}" \
 			--header "Accept: application/json" \
 			--header "Authorization: Bearer ${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" \
 			--header "Content-Type: multipart/form-data" \
 			--request PUT \
-			--silent \
-			--write-out "%output{${http_status_code_file}}%{http_code}" \
 			${LIFERAY_BATCH_CURL_OPTIONS} \
-			"${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code}")
-
-	local http_status_code=$(cat "${http_status_code_file}")
-
-	if [[ "${http_status_code}" -ge 400 ]]
+			"${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code}"
 	then
-		echo "PUT ${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code} errored with HTTP status ${http_status_code}."
+		echo "PUT ${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}."
 
 		return 1
 	fi
 
-	echo "PUT Response: ${put_response}"
+	echo "PUT Response: ${LIFERAY_BATCH_HTTP_BODY}"
 	echo ""
 
-	if [ ! -n "${put_response}" ]
+	if [ ! -n "${LIFERAY_BATCH_HTTP_BODY}" ]
 	then
 		echo "Received empty PUT response. Check Liferay logs for more information."
 
@@ -204,28 +211,19 @@ function process_site_initializer {
 }
 
 function request_oauth2_access_token {
-	local http_status_code_file=$(mktemp)
-
-	local oauth2_token_response=$( \
-		curl \
+	if ! execute_curl \
 			--data "client_id=${LIFERAY_BATCH_OAUTH2_CLIENT_ID}&client_secret=${LIFERAY_BATCH_OAUTH2_CLIENT_SECRET}&grant_type=client_credentials" \
 			--header "Content-type: application/x-www-form-urlencoded" \
 			--request POST \
-			--silent \
-			--write-out "%output{${http_status_code_file}}%{http_code}" \
 			${LIFERAY_BATCH_CURL_OPTIONS} \
-			"${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI}")
-
-	local http_status_code=$(cat "${http_status_code_file}")
-
-	if [[ "${http_status_code}" -ge 400 ]]
+			"${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI}"
 	then
-		echo "POST ${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI} errored with HTTP status ${http_status_code}."
+		echo "POST ${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}."
 
 		return 1
 	fi
 
-	LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN=$(jq --raw-output ".access_token" <<< "${oauth2_token_response}")
+	LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN=$(jq --raw-output ".access_token" <<< "${LIFERAY_BATCH_HTTP_BODY}")
 
 	if [ "${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" == "" ]
 	then
@@ -243,26 +241,19 @@ function wait_for_import_task {
 
 	until [ "${status}" == "COMPLETED" ] || [ "${status}" == "FAILED" ] || [ "${status}" == "NOT_FOUND" ]
 	do
-		local http_status_code_file=$(mktemp)
-
-		local get_response=$( \
-			curl \
-				--header "accept: application/json" \
+		if ! execute_curl \
+				--header "Accept: application/json" \
 				--header "Authorization: Bearer ${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" \
-				--request 'GET' \
-				--silent \
-				--write-out "%output{${http_status_code_file}}%{http_code}" \
+				--request GET \
 				${LIFERAY_BATCH_CURL_OPTIONS} \
-				"${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code}")
-
-		if [[ "${http_status_code}" -ge 400 ]]
+				"${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code}"
 		then
-			echo "GET ${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code} errored with HTTP status ${http_status_code}."
+			echo "GET ${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}."
 
 			return 1
 		fi
 
-		status=$(jq --raw-output '.executeStatus//.status' <<< "${get_response}")
+		status=$(jq --raw-output '.executeStatus//.status' <<< "${LIFERAY_BATCH_HTTP_BODY}")
 
 		echo "Execute Status: ${status}"
 	done

--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -88,7 +88,9 @@ function main {
 
 	log "OAuth Application ERC: ${LIFERAY_BATCH_OAUTH_APP_ERC}"
 
-	local lxc_dxp_main_domain=$(cat "${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.main.domain")
+	local lxc_dxp_main_domain
+
+	lxc_dxp_main_domain=$(cat "${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.main.domain")
 
 	if [ ! -n "${lxc_dxp_main_domain}" ]
 	then
@@ -127,11 +129,15 @@ function process_batch_data_file {
 
 	log "Processing: ${file_name}"
 
-	local href=$(jq --raw-output ".actions.createBatch.href" "${file_name}")
+	local href
+
+	href=$(jq --raw-output ".actions.createBatch.href" "${file_name}")
 
 	if [ "${href}" == "null" ]
 	then
-		local class_name=$(jq --raw-output ".configuration.className" "${file_name}")
+		local class_name
+
+		class_name=$(jq --raw-output ".configuration.className" "${file_name}")
 
 		if [ "${class_name}" == "null" ]
 		then
@@ -156,7 +162,9 @@ function process_batch_data_file {
 
 	log "Items: $(</tmp/liferay_batch_entrypoint.items.json)"
 
-	local parameters=$(jq --raw-output '.configuration.parameters | [map_values(. | @uri) | to_entries[] | .key + "=" + .value] | join("&")' "${file_name}" 2> /dev/null)
+	local parameters
+
+	parameters=$(jq --raw-output '.configuration.parameters | [map_values(. | @uri) | to_entries[] | .key + "=" + .value] | join("&")' "${file_name}" 2> /dev/null)
 
 	if [ "${parameters}" != "" ]
 	then
@@ -195,7 +203,9 @@ function process_batch_data_file {
 		return 1
 	fi
 
-	local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${LIFERAY_BATCH_HTTP_BODY}")
+	local external_reference_code
+
+	external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${LIFERAY_BATCH_HTTP_BODY}")
 
 	wait_for_import_task "${external_reference_code}"
 
@@ -218,11 +228,15 @@ function process_site_initializer {
 
 	log "HREF: ${href}"
 
-	local site=$(jq --raw-output '.' "${LIFERAY_BATCH_SITE_INITIALIZER_DIR}/site-initializer.json")
+	local site
+
+	site=$(jq --raw-output '.' "${LIFERAY_BATCH_SITE_INITIALIZER_DIR}/site-initializer.json")
 
 	log "Site: ${site}"
 
-	local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${site}")
+	local external_reference_code
+
+	external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${site}")
 
 	if ! execute_curl \
 			--form "file=@${LIFERAY_BATCH_SITE_INITIALIZER_DIR}/site-initializer.zip;type=application/zip" \

--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -135,6 +135,11 @@ function process_batch_data_file {
 
 	echo "Parameters: ${parameters}"
 
+	if ! refresh_oauth2_access_token
+	then
+		return 1
+	fi
+
 	if ! execute_curl \
 			--data @/tmp/liferay_batch_entrypoint.items.json \
 			--header "Accept: application/json" \
@@ -219,6 +224,15 @@ function process_site_initializer {
 	return 0
 }
 
+function refresh_oauth2_access_token {
+	if [ $((SECONDS - LIFERAY_BATCH_OAUTH2_TOKEN_SECONDS)) -lt 480 ]
+	then
+		return 0
+	fi
+
+	request_oauth2_access_token
+}
+
 function request_oauth2_access_token {
 	if ! execute_curl \
 			--data "client_id=${LIFERAY_BATCH_OAUTH2_CLIENT_ID}&client_secret=${LIFERAY_BATCH_OAUTH2_CLIENT_SECRET}&grant_type=client_credentials" \
@@ -241,6 +255,8 @@ function request_oauth2_access_token {
 		return 1
 	fi
 
+	LIFERAY_BATCH_OAUTH2_TOKEN_SECONDS=${SECONDS}
+
 	return 0
 }
 
@@ -252,6 +268,11 @@ function wait_for_import_task {
 
 	while true
 	do
+		if ! refresh_oauth2_access_token
+		then
+			return 1
+		fi
+
 		if ! execute_curl \
 				--header "Accept: application/json" \
 				--header "Authorization: Bearer ${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" \

--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -139,7 +139,7 @@ function process_batch_data_file {
 			${LIFERAY_BATCH_CURL_OPTIONS} \
 			"${LIFERAY_BATCH_DXP_URL}${href}${parameters}"
 	then
-		echo "POST ${LIFERAY_BATCH_DXP_URL}${href}${parameters} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}."
+		echo "POST ${LIFERAY_BATCH_DXP_URL}${href}${parameters} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}"
 
 		return 1
 	fi
@@ -192,7 +192,7 @@ function process_site_initializer {
 			${LIFERAY_BATCH_CURL_OPTIONS} \
 			"${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code}"
 	then
-		echo "PUT ${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}."
+		echo "PUT ${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}"
 
 		return 1
 	fi
@@ -218,7 +218,7 @@ function request_oauth2_access_token {
 			${LIFERAY_BATCH_CURL_OPTIONS} \
 			"${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI}"
 	then
-		echo "POST ${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}."
+		echo "POST ${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}"
 
 		return 1
 	fi
@@ -248,7 +248,7 @@ function wait_for_import_task {
 				${LIFERAY_BATCH_CURL_OPTIONS} \
 				"${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code}"
 		then
-			echo "GET ${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}."
+			echo "GET ${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}"
 
 			return 1
 		fi

--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -25,10 +25,33 @@ function execute_curl {
 	return 0
 }
 
+function log {
+	if [ "${LIFERAY_STRUCTURED_LOGGING_ENABLED}" != "true" ]
+	then
+		echo "${1}"
+
+		return
+	fi
+
+	#
+	# The message is piped rather than passed with --arg. A log line can carry an
+	# entire batch data file's items, which is well past ARG_MAX, and as an
+	# argument that fails the exec and loses the line entirely.
+	#
+
+	printf "%s" "${1}" | jq \
+		--arg severity "${2:-INFO}" \
+		--arg timestamp "$(date --utc +%Y-%m-%dT%H:%M:%SZ)" \
+		--compact-output \
+		--raw-input \
+		--slurp \
+		'{"message": ., "script": "liferay_batch_entrypoint.sh", "severity": $severity, "timestamp": $timestamp}'
+}
+
 function main {
 	if [ ! -n "${LIFERAY_BATCH_OAUTH_APP_ERC}" ]
 	then
-		echo "Set the environment variable LIFERAY_BATCH_OAUTH_APP_ERC."
+		log "Set the environment variable LIFERAY_BATCH_OAUTH_APP_ERC." ERROR
 
 		exit 1
 	fi
@@ -63,8 +86,7 @@ function main {
 		LIFERAY_ROUTES_DXP="/etc/liferay/lxc/dxp-metadata"
 	fi
 
-	echo "OAuth Application ERC: ${LIFERAY_BATCH_OAUTH_APP_ERC}"
-	echo ""
+	log "OAuth Application ERC: ${LIFERAY_BATCH_OAUTH_APP_ERC}"
 
 	local lxc_dxp_main_domain=$(cat "${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.main.domain")
 
@@ -78,8 +100,7 @@ function main {
 	LIFERAY_BATCH_OAUTH2_CLIENT_SECRET=$(cat "${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.headless.server.client.secret")
 	LIFERAY_BATCH_OAUTH2_TOKEN_URI=$(cat "${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.token.uri")
 
-	echo "DXP URL: ${LIFERAY_BATCH_DXP_URL}"
-	echo ""
+	log "DXP URL: ${LIFERAY_BATCH_DXP_URL}"
 
 	if ! request_oauth2_access_token
 	then
@@ -104,8 +125,7 @@ function main {
 function process_batch_data_file {
 	local file_name="${1}"
 
-	echo "Processing: ${file_name}"
-	echo ""
+	log "Processing: ${file_name}"
 
 	local href=$(jq --raw-output ".actions.createBatch.href" "${file_name}")
 
@@ -115,7 +135,7 @@ function process_batch_data_file {
 
 		if [ "${class_name}" == "null" ]
 		then
-			echo "Batch data file is missing configuration class name."
+			log "Batch data file is missing configuration class name." ERROR
 
 			return 1
 		fi
@@ -130,11 +150,11 @@ function process_batch_data_file {
 		href="/${href}"
 	fi
 
-	echo "HREF: ${href}"
+	log "HREF: ${href}"
 
 	jq --raw-output ".items" "${file_name}" > /tmp/liferay_batch_entrypoint.items.json
 
-	echo "Items: $(</tmp/liferay_batch_entrypoint.items.json)"
+	log "Items: $(</tmp/liferay_batch_entrypoint.items.json)"
 
 	local parameters=$(jq --raw-output '.configuration.parameters | [map_values(. | @uri) | to_entries[] | .key + "=" + .value] | join("&")' "${file_name}" 2> /dev/null)
 
@@ -143,7 +163,7 @@ function process_batch_data_file {
 		parameters="?${parameters}"
 	fi
 
-	echo "Parameters: ${parameters}"
+	log "Parameters: ${parameters}"
 
 	if ! refresh_oauth2_access_token
 	then
@@ -159,17 +179,16 @@ function process_batch_data_file {
 			${LIFERAY_BATCH_CURL_OPTIONS} \
 			"${LIFERAY_BATCH_DXP_URL}${href}${parameters}"
 	then
-		echo "POST ${LIFERAY_BATCH_DXP_URL}${href}${parameters} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}"
+		log "POST ${LIFERAY_BATCH_DXP_URL}${href}${parameters} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}" ERROR
 
 		return 1
 	fi
 
-	echo "POST Response: ${LIFERAY_BATCH_HTTP_BODY}"
-	echo ""
+	log "POST Response: ${LIFERAY_BATCH_HTTP_BODY}"
 
 	if [ ! -n "${LIFERAY_BATCH_HTTP_BODY}" ]
 	then
-		echo "Received empty POST response. Check Liferay logs for more information."
+		log "Received empty POST response. Check Liferay logs for more information." ERROR
 
 		rm /tmp/liferay_batch_entrypoint.items.json
 
@@ -193,16 +212,15 @@ function process_site_initializer {
 		return 0
 	fi
 
-	echo "Processing: ${LIFERAY_BATCH_SITE_INITIALIZER_DIR}/site-initializer.json"
-	echo ""
+	log "Processing: ${LIFERAY_BATCH_SITE_INITIALIZER_DIR}/site-initializer.json"
 
 	local href="/o/headless-site/v1.0/sites/by-external-reference-code/"
 
-	echo "HREF: ${href}"
+	log "HREF: ${href}"
 
 	local site=$(jq --raw-output '.' "${LIFERAY_BATCH_SITE_INITIALIZER_DIR}/site-initializer.json")
 
-	echo "Site: ${site}"
+	log "Site: ${site}"
 
 	local external_reference_code=$(jq --raw-output ".externalReferenceCode" <<< "${site}")
 
@@ -216,17 +234,16 @@ function process_site_initializer {
 			${LIFERAY_BATCH_CURL_OPTIONS} \
 			"${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code}"
 	then
-		echo "PUT ${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}"
+		log "PUT ${LIFERAY_BATCH_DXP_URL}${href}${external_reference_code} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}" ERROR
 
 		return 1
 	fi
 
-	echo "PUT Response: ${LIFERAY_BATCH_HTTP_BODY}"
-	echo ""
+	log "PUT Response: ${LIFERAY_BATCH_HTTP_BODY}"
 
 	if [ ! -n "${LIFERAY_BATCH_HTTP_BODY}" ]
 	then
-		echo "Received empty PUT response. Check Liferay logs for more information."
+		log "Received empty PUT response. Check Liferay logs for more information." ERROR
 
 		return 1
 	fi
@@ -251,7 +268,7 @@ function request_oauth2_access_token {
 			${LIFERAY_BATCH_CURL_OPTIONS} \
 			"${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI}"
 	then
-		echo "POST ${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}"
+		log "POST ${LIFERAY_BATCH_DXP_URL}${LIFERAY_BATCH_OAUTH2_TOKEN_URI} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}" ERROR
 
 		return 1
 	fi
@@ -260,7 +277,7 @@ function request_oauth2_access_token {
 
 	if [ "${LIFERAY_BATCH_OAUTH2_ACCESS_TOKEN}" == "" ]
 	then
-		echo "Unable to get OAuth 2 access token."
+		log "Unable to get OAuth 2 access token." ERROR
 
 		return 1
 	fi
@@ -290,7 +307,7 @@ function wait_for_import_task {
 				${LIFERAY_BATCH_CURL_OPTIONS} \
 				"${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code}"
 		then
-			echo "GET ${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}"
+			log "GET ${LIFERAY_BATCH_DXP_URL}/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/${external_reference_code} errored with HTTP status ${LIFERAY_BATCH_HTTP_STATUS}. ${LIFERAY_BATCH_HTTP_BODY}" ERROR
 
 			return 1
 		fi
@@ -299,12 +316,12 @@ function wait_for_import_task {
 
 		if ! status=$(jq --exit-status --raw-output '.executeStatus//.status' <<< "${LIFERAY_BATCH_HTTP_BODY}")
 		then
-			echo "Unable to read a status for batch import task ${external_reference_code}. ${LIFERAY_BATCH_HTTP_BODY}"
+			log "Unable to read a status for batch import task ${external_reference_code}. ${LIFERAY_BATCH_HTTP_BODY}" ERROR
 
 			return 1
 		fi
 
-		echo "Execute Status: ${status}"
+		log "Execute Status: ${status}"
 
 		if [ "${status}" == "COMPLETED" ]
 		then
@@ -314,7 +331,7 @@ function wait_for_import_task {
 
 			if [ "${failed_items}" != "0" ]
 			then
-				echo "Batch import task ${external_reference_code} completed with ${failed_items} failed item(s). ${LIFERAY_BATCH_HTTP_BODY}"
+				log "Batch import task ${external_reference_code} completed with ${failed_items} failed item(s). ${LIFERAY_BATCH_HTTP_BODY}" ERROR
 
 				return 1
 			fi
@@ -324,14 +341,14 @@ function wait_for_import_task {
 
 		if [ "${status}" == "FAILED" ] || [ "${status}" == "NOT_FOUND" ]
 		then
-			echo "Batch import task ${external_reference_code} reported ${status}. ${LIFERAY_BATCH_HTTP_BODY}"
+			log "Batch import task ${external_reference_code} reported ${status}. ${LIFERAY_BATCH_HTTP_BODY}" ERROR
 
 			return 1
 		fi
 
 		if [ "${waited_seconds}" -ge "${LIFERAY_BATCH_MAX_WAIT_SECONDS}" ]
 		then
-			echo "Batch import task ${external_reference_code} did not reach a terminal state within ${waited_seconds} seconds. The last reported status was ${status}."
+			log "Batch import task ${external_reference_code} did not reach a terminal state within ${waited_seconds} seconds. The last reported status was ${status}." ERROR
 
 			return 1
 		fi

--- a/test_liferay_batch_entrypoint.sh
+++ b/test_liferay_batch_entrypoint.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+
+source ./_env_common.sh
+source ./_test_common.sh
+
+function main {
+	test_liferay_batch_entrypoint_import_task_status
+	test_liferay_batch_entrypoint_polls_with_backoff
+	test_liferay_batch_entrypoint_reports_completed_with_failed_items
+	test_liferay_batch_entrypoint_reports_post_error_body
+	test_liferay_batch_entrypoint_reports_unparseable_poll_response
+	test_liferay_batch_entrypoint_requires_oauth_app_erc
+}
+
+function test_liferay_batch_entrypoint_import_task_status {
+	_test_liferay_batch_entrypoint_import_task_status "{\"executeStatus\": \"COMPLETED\", \"failedItems\": []}" "0"
+	_test_liferay_batch_entrypoint_import_task_status "{\"executeStatus\": \"FAILED\"}" "1"
+	_test_liferay_batch_entrypoint_import_task_status "{\"status\": \"NOT_FOUND\"}" "1"
+}
+
+function test_liferay_batch_entrypoint_polls_with_backoff {
+	set_up
+
+	export _TEST_POLL_BODY="{\"executeStatus\": \"STARTED\"}"
+
+	_TEST_ENTRYPOINT_OUTPUT=$(LIFERAY_BATCH_MAX_WAIT_SECONDS=3 _run_entrypoint)
+
+	_TEST_ENTRYPOINT_EXIT_CODE="${?}"
+
+	assert_equals \
+		"$(wc --lines < "${_TEST_FIXTURE_DIR}/poll_count")" "3" \
+		"$(_output_contains "did not reach a terminal state")" "true"
+
+	tear_down
+}
+
+function test_liferay_batch_entrypoint_reports_completed_with_failed_items {
+	set_up
+
+	export _TEST_POLL_BODY="{\"executeStatus\": \"COMPLETED\", \"failedItems\": [{\"itemIndex\": 3}]}"
+
+	_TEST_ENTRYPOINT_OUTPUT=$(_run_entrypoint)
+
+	_TEST_ENTRYPOINT_EXIT_CODE="${?}"
+
+	assert_equals \
+		"$(_output_contains "completed with 1 failed item(s)")" "true" \
+		"${_TEST_ENTRYPOINT_EXIT_CODE}" "1"
+
+	tear_down
+}
+
+function test_liferay_batch_entrypoint_reports_post_error_body {
+	set_up
+
+	export _TEST_POST_BODY="{\"status\": \"BAD_REQUEST\", \"title\": \"This external reference code is already in use.\"}"
+	export _TEST_POST_HTTP_STATUS="400"
+
+	_TEST_ENTRYPOINT_OUTPUT=$(_run_entrypoint)
+
+	_TEST_ENTRYPOINT_EXIT_CODE="${?}"
+
+	assert_equals \
+		"$(_output_contains "already in use")" "true" \
+		"$(_output_contains "HTTP status 400")" "true" \
+		"${_TEST_ENTRYPOINT_EXIT_CODE}" "1"
+
+	tear_down
+}
+
+function test_liferay_batch_entrypoint_reports_unparseable_poll_response {
+	set_up
+
+	export _TEST_POLL_BODY="<html><body>502 Bad Gateway</body></html>"
+
+	_TEST_ENTRYPOINT_OUTPUT=$(_run_entrypoint)
+
+	_TEST_ENTRYPOINT_EXIT_CODE="${?}"
+
+	assert_equals \
+		"$(wc --lines < "${_TEST_FIXTURE_DIR}/poll_count")" "1" \
+		"$(_output_contains "Unable to read a status")" "true" \
+		"${_TEST_ENTRYPOINT_EXIT_CODE}" "1"
+
+	tear_down
+}
+
+function test_liferay_batch_entrypoint_requires_oauth_app_erc {
+	set_up
+
+	_TEST_ENTRYPOINT_OUTPUT=$(LIFERAY_BATCH_OAUTH_APP_ERC="" _run_entrypoint)
+
+	_TEST_ENTRYPOINT_EXIT_CODE="${?}"
+
+	assert_equals \
+		"$(_output_contains "Set the environment variable LIFERAY_BATCH_OAUTH_APP_ERC.")" "true" \
+		"${_TEST_ENTRYPOINT_EXIT_CODE}" "1"
+
+	tear_down
+}
+
+function set_up {
+	common_set_up
+
+	_TEST_FIXTURE_DIR=$(mktemp --directory)
+
+	mkdir --parents \
+		"${_TEST_FIXTURE_DIR}/batch" \
+		"${_TEST_FIXTURE_DIR}/bin" \
+		"${_TEST_FIXTURE_DIR}/lxc/dxp-metadata" \
+		"${_TEST_FIXTURE_DIR}/lxc/ext-init-metadata"
+
+	echo "localhost" > "${_TEST_FIXTURE_DIR}/lxc/dxp-metadata/com.liferay.lxc.dxp.main.domain"
+	echo "http" > "${_TEST_FIXTURE_DIR}/lxc/dxp-metadata/com.liferay.lxc.dxp.server.protocol"
+	echo "id" > "${_TEST_FIXTURE_DIR}/lxc/ext-init-metadata/test.oauth2.headless.server.client.id"
+	echo "secret" > "${_TEST_FIXTURE_DIR}/lxc/ext-init-metadata/test.oauth2.headless.server.client.secret"
+	echo "/o/oauth2/token" > "${_TEST_FIXTURE_DIR}/lxc/ext-init-metadata/test.oauth2.token.uri"
+
+	echo "{\"configuration\": {\"className\": \"Foo\", \"parameters\": {\"createStrategy\": \"UPSERT\"}}, \"items\": [{\"name\": \"x\"}]}" > "${_TEST_FIXTURE_DIR}/batch/00-test.batch-engine-data.json"
+
+	touch "${_TEST_FIXTURE_DIR}/poll_count"
+
+	_write_curl_stub
+
+	export _TEST_POLL_BODY="{\"executeStatus\": \"COMPLETED\", \"failedItems\": []}"
+	export _TEST_POLL_HTTP_STATUS="200"
+	export _TEST_POST_BODY="{\"externalReferenceCode\": \"ERC-1\"}"
+	export _TEST_POST_HTTP_STATUS="200"
+	export _TEST_POLL_COUNT_FILE="${_TEST_FIXTURE_DIR}/poll_count"
+	export _TEST_TOKEN_BODY="{\"access_token\": \"token\", \"expires_in\": 600}"
+	export _TEST_TOKEN_HTTP_STATUS="200"
+}
+
+function tear_down {
+	common_tear_down
+
+	rm --force --recursive "${_TEST_FIXTURE_DIR}"
+
+	unset _TEST_POLL_BODY
+	unset _TEST_POLL_COUNT_FILE
+	unset _TEST_POLL_HTTP_STATUS
+	unset _TEST_POST_BODY
+	unset _TEST_POST_HTTP_STATUS
+	unset _TEST_TOKEN_BODY
+	unset _TEST_TOKEN_HTTP_STATUS
+}
+
+function _output_contains {
+	if [[ "${_TEST_ENTRYPOINT_OUTPUT}" == *"${1}"* ]]
+	then
+		echo "true"
+
+		return 0
+	fi
+
+	echo "false"
+
+	return 1
+}
+
+function _run_entrypoint {
+	PATH="${_TEST_FIXTURE_DIR}/bin:${PATH}" \
+	LIFERAY_BATCH_DIR="${_TEST_FIXTURE_DIR}/batch" \
+	LIFERAY_BATCH_OAUTH_APP_ERC="${LIFERAY_BATCH_OAUTH_APP_ERC-test}" \
+	LIFERAY_BATCH_SITE_INITIALIZER_DIR="${_TEST_FIXTURE_DIR}/no-site-initializer" \
+	LIFERAY_ROUTES_CLIENT_EXTENSION="${_TEST_FIXTURE_DIR}/lxc/ext-init-metadata" \
+	LIFERAY_ROUTES_DXP="${_TEST_FIXTURE_DIR}/lxc/dxp-metadata" \
+		bash ./templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh 2>&1
+}
+
+function _test_liferay_batch_entrypoint_import_task_status {
+	set_up
+
+	export _TEST_POLL_BODY="${1}"
+
+	_TEST_ENTRYPOINT_OUTPUT=$(LIFERAY_BATCH_MAX_WAIT_SECONDS=3 _run_entrypoint)
+
+	_TEST_ENTRYPOINT_EXIT_CODE="${?}"
+
+	assert_equals "${_TEST_ENTRYPOINT_EXIT_CODE}" "${2}"
+
+	tear_down
+}
+
+function _write_curl_stub {
+	cat > "${_TEST_FIXTURE_DIR}/bin/curl" <<-STUB_EOF
+		#!/bin/bash
+
+		url="\${@: -1}"
+
+		if [[ "\${url}" == */o/oauth2/token ]]
+		then
+			echo "\${_TEST_TOKEN_BODY}"
+			echo "\${_TEST_TOKEN_HTTP_STATUS}"
+		elif [[ "\${url}" == */by-external-reference-code/* ]]
+		then
+			echo "poll" >> "\${_TEST_POLL_COUNT_FILE}"
+
+			echo "\${_TEST_POLL_BODY}"
+			echo "\${_TEST_POLL_HTTP_STATUS}"
+		else
+			echo "\${_TEST_POST_BODY}"
+			echo "\${_TEST_POST_HTTP_STATUS}"
+		fi
+	STUB_EOF
+
+	chmod +x "${_TEST_FIXTURE_DIR}/bin/curl"
+}
+
+main


### PR DESCRIPTION
The batch client extension's entrypoint swallows the information needed to
diagnose a failed import, and reports success for two failure modes. Debugging a
seeding failure in a local environment meant reproducing the batch engine call
by hand to read an error the script had already received and discarded.

Nine commits, each independently reviewable. The first is a pure refactor with
no behavior change, and every behavioral change after it is isolated:

1. Extract the steps into functions — 1 function becomes 5, every body verbatim
2. Stop logging the OAuth client secret and access token
3. Detect HTTP failures while polling the import task
4. Log the response body when a request fails
5. Fail when an import task is not found or has failed items
6. Poll the import task with backoff and a wait ceiling
7. Refresh the OAuth token while polling
8. Add a test for the batch entrypoint
9. Emit structured JSON logs when structured logging is enabled

### What was wrong

**The error body was captured and then thrown away.** The failure branch printed
only the status code, while the body was echoed further down on the success path
that a failed request never reaches. A 400 logged as `errored with HTTP status
400.` when the response said `"This external reference code is already in use."`

**The status code check in the poll loop tested a stale value.** The
curl-status idiom appeared four times: `mktemp` four times, the `-ge 400`
comparison four times, but the read-back only three. The poll wrote its status
to a fresh temp file and never read it, so it compared the code left over from
the earlier POST. Transport errors and 5xx during polling were undetectable, and
with no delay in the loop the script retried until the pod was killed.

**Two failure modes reported success.** `NOT_FOUND` ended the poll loop and fell
through to the success path, and a `COMPLETED` task carrying `failedItems` was
never inspected, so per-item import failures passed the Job silently.

**Non-JSON responses spun forever.** The status was read without checking `jq`,
which exits 0 and prints nothing for an empty body, so an HTML error page from
the ingress left the status empty — and no empty value matches a terminal state.

**The OAuth token outlived the poll loop.** `expires_in` is 600 seconds, the
token was requested once before the first file, and polling was unbounded.

**The client secret and full token response were printed to the pod log.**

### Measurements

Against a live 16-file import, verified by comparing the released image
(`md5 2fdc5f0e…`) with this branch (`md5 82a95023…`) inside the running pods:

| | released | this branch |
|---|---|---|
| polls for 16 files | **1,981** | **39** |
| wall clock | 28.2s | 47.4s |
| error bodies | discarded | logged |
| secret in pod log | yes | no |

Three slow imports accounted for 1,864 of the 1,981 polls — the loop spins
flat-out for the whole duration of each server-side import. Roughly 51x fewer
requests for the same work.

Behavior across failure modes, driven through a stubbed `curl`:

| scenario | released | this branch |
|---|---|---|
| success | exit 0 | exit 0 |
| task never finishes | hangs (1,930 polls) | exit 1 |
| non-JSON poll response | hangs (1,662 polls) | exit 1 |
| COMPLETED with failed items | **exit 0** | exit 1 |
| NOT_FOUND | **exit 0** | exit 1 |
| 5xx during polling | hangs (1,617 polls) | exit 1 |
| error on POST | exit 1 | exit 1 |

The first commit reproduces the released behavior exactly on all of these,
including the hangs, which is what makes it a safe refactor.

### JSON logging

The bundle image already gates a JSON console layout behind
`LIFERAY_STRUCTURED_LOGGING_ENABLED`, but the batch image logged plain text, so a
batch failure in a project collecting structured logs arrived as an unparsed
string. The same variable now switches this entrypoint to the
`{message, script, severity, timestamp}` shape used by the cloud helm scripts,
with failures carrying `severity` of `ERROR`. Default is off.

The record is built with `jq` rather than by escaping with `sed`. Every failure
message embeds a response body, and those bodies are pretty-printed JSON
containing quotes, backslashes and newlines, which a `sed` escape turns into an
invalid record. Verified against a deliberately hostile body: all emitted lines
parse.

### Tests

`test_liferay_batch_entrypoint.sh` at the repo root, since `run_tests.sh`
discovers root-level `test_*.sh`. It stubs `curl` on `PATH` and drives the
entrypoint through each failure mode above. Driving the script requires the batch
and site-initializer directories to be overridable, so both now fall back to
their image paths rather than being hardcoded. 8 assertions, all passing.

### Notes

`onErrorFail`, `containsHeaders` and `taskItemDelegateName` are accepted and
ignored by the endpoint, while `updateStrategy` is parsed and validated
(`updateStrategy=UPDATE` returns 200, `updateStrategy=upsert` returns 500) — so
no warning about unknown parameters is included here, since it would fire
falsely.
